### PR TITLE
working HTML escaping :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,9 @@ Clabango's template inheritance is modeled on Django's -- docs available here: h
 </body>
 </html>
 ```
+
+By default Clabango will escape HTML in strings, if you wish to disable escaping simply pass in `:escape false` as the last argument:
+
+```clojure
+(render-file "example/templates/index.html" {:greeting "Hey!"} :escape false)
+```

--- a/src/clabango/filters.clj
+++ b/src/clabango/filters.clj
@@ -75,7 +75,7 @@
         single
         plural))))
 
-(deftemplatefilter "to-json" [node body arg]
+(deftemplatefilter "to-json" [node body arg]  
   (if body
     (cheshire/encode body)
     "null"))


### PR DESCRIPTION
I fixed up the HTML escaping @bitemyapp added

The escaping will now happen by default unless `:escape false` is passed in to `render` and `render-file` as the last argument.

`to-json` will always set escaping to `false` so that json doesn't get mangled, added tests for all cases and updated docs, hopefully this is acceptable.
