### PR TITLE
Speed improvements, due to type-hinting and changes in escaping

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,7 @@
                  [commons-codec "1.6"]
                  [joda-time "2.1"]
                  [net.sf.opencsv/opencsv "2.3"]
-                 [criterium "0.3.1" :scope "test"]
-                 [org.apache.commons/commons-lang3 "3.1"]]
+                 [criterium "0.3.1" :scope "test"]]
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark
                    :all (constantly true)}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/BSD-3-Clause"
             :distribution :repo}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [cheshire "5.0.2"]
+                 [cheshire "5.2.0"]
                  [commons-codec "1.6"]
                  [joda-time "2.1"]
                  [net.sf.opencsv/opencsv "2.3"]
@@ -13,4 +13,5 @@
                  [org.apache.commons/commons-lang3 "3.1"]]
   :test-selectors {:default (complement :benchmark)
                    :benchmark :benchmark
-                   :all (constantly true)})
+                   :all (constantly true)}
+  :warn-on-reflection true)

--- a/src/clabango/filters.clj
+++ b/src/clabango/filters.clj
@@ -2,12 +2,12 @@
   (:require [cheshire.core :as cheshire])
   (:import (org.apache.commons.codec.digest DigestUtils)
            (org.joda.time Instant)
-           (org.joda.time.format DateTimeFormat)))
+           (org.joda.time.format DateTimeFormat DateTimeFormatter)))
 
 (defn context-lookup
-  ([context var]
+  ([context ^String var]
      (context-lookup context var nil))
-  ([context var default]
+  ([context ^String var default]
      (get-in context (map keyword (.split var "\\.")) default)))
 
 (defmulti template-filter (fn [filter-name _ _ _] filter-name))
@@ -21,7 +21,7 @@
 (defmacro deftemplatefilter [filter-name & fn-tail]
   `(defmethod template-filter ~filter-name ~@(fix-args fn-tail)))
 
-(deftemplatefilter "upper" [node body arg]
+(deftemplatefilter "upper" [node ^String body arg]
   (when body
     {:body (.toUpperCase body)}))
 
@@ -36,10 +36,10 @@
     (if (not arg)
       (throw (Exception.
               (str "date filter requires a format string argument " node)))
-      {:body (.print (get-date-formatter (subs arg 1 (dec (count arg))))
+      {:body (.print ^DateTimeFormatter (get-date-formatter (subs arg 1 (dec (count arg))))
                      (Instant. body))})))
 
-(deftemplatefilter "hash" [node body arg]
+(deftemplatefilter "hash" [node ^String body arg]
   (when body
     (if (not arg)
       (throw (Exception.

--- a/src/clabango/parser.clj
+++ b/src/clabango/parser.clj
@@ -9,7 +9,7 @@
 
 (declare lex* string->ast ast->groups)
 
-(defn start-of-new-token? [s i]
+(defn start-of-new-token? [^String s i]
   (let [c (.charAt s i)
         nc (try
              (.charAt s (inc i))
@@ -23,7 +23,7 @@
         (and (= c \})
              (= nc \})))))
 
-(defn buffer-string [s fileref i max offset line]
+(defn buffer-string [^String s fileref i max offset line]
   (let [sb (StringBuffer.)]
     (loop [ni i]
       (if (or (>= ni max)
@@ -37,7 +37,7 @@
           (.append sb (.charAt s ni))
           (recur (inc ni)))))))
 
-(defn lex* [s fileref i max offset line]
+(defn lex* [^String s fileref i max offset line]
   (lazy-seq
    (when (< i max)
      (let [c (.charAt s i)
@@ -79,7 +79,7 @@
          (buffer-string s fileref i max offset line))))))
 
 (defn lex [string-or-file]
-  (let [[s fileref] (if (string? string-or-file)
+  (let [[^String s fileref] (if (string? string-or-file)
                       [string-or-file "UNKNOWN"]
                       [(slurp string-or-file) string-or-file])
         max (.length s)]
@@ -131,7 +131,7 @@
    (when-let [node (first ast)]
      (if (= :tag (:type node))
        (let [[tag & args] (map first (re-seq #"[^\s\"']+|\"([^\"]*)\"|'([^']*)'"
-                                             (.trim (:token (:body node)))))]
+                                             (.trim ^String (:token (:body node)))))]
          (if (valid-tag? tag)
            (cons (assoc node
                    :tag-name tag
@@ -217,12 +217,12 @@
    (when-let [node (first ast)]
      (case (:type node)
        :filter
-       (let [[var & filters] (get-filters (.trim (:token (:body node))))]
+       (let [[var & filters] (get-filters (.trim ^String (:token (:body node))))]
          (cons
           (update-in
            (reduce
-            (fn [node filter-and-args]
-              (let [[filter-name arg] (.split filter-and-args ":" 2)
+            (fn [node ^String filter-and-args]
+              (let [[filter-name ^String arg] (.split filter-and-args ":" 2)
                     body (get-in node [:body :token])]
                 (if (and arg
                          (not (and (.startsWith arg "\"")

--- a/src/clabango/tags.clj
+++ b/src/clabango/tags.clj
@@ -72,7 +72,7 @@
   (let [if-node (first nodes)
         operands (:args if-node)
         body-nodes (rest (butlast nodes))]
-    {:nodes (if (apply = (for [op operands]
+    {:nodes (if (apply = (for [^String op operands]
                            (if (= \" (.charAt op 0))
                              (subs op 1 (dec (count op)))
                              (context-lookup context op))))


### PR DESCRIPTION
HTML escaping is about 2x as fast (was previously eating up 35-40% of runtime)

Type-hints comprise most of the overall ~2-3x improvement.
